### PR TITLE
fix: guard mapFireToAlt when body has no gunsArrayed

### DIFF
--- a/server/miscFiles/controllers.js
+++ b/server/miscFiles/controllers.js
@@ -371,7 +371,9 @@ class io_mapFireToAlt extends IO {
         this.onlyIfHasAltFireGun = opts.onlyIfHasAltFireGun;
     }
     think(input) {
-        if (input.fire) for (let i = 0; i < this.body.gunsArrayed.length; i++) if (!this.onlyIfHasAltFireGun || this.body.gunsArrayed[i].altFire) return { alt: true }
+        if (input.fire && this.body.gunsArrayed) {
+            for (let i = 0; i < this.body.gunsArrayed.length; i++) if (!this.onlyIfHasAltFireGun || this.body.gunsArrayed[i].altFire) return { alt: true }
+        }
     }
 }
 class io_onlyAcceptInArc extends IO {


### PR DESCRIPTION
Closes #46 

The `mapFireToAlt` controller was reading `this.body.gunsArrayed.length` unconditionally but `gunsArrayed` only ever gets set up for regular entities. `turretEntity` never initializes it, so whenever a turret (or anything else without that property) got the `mapFireToAlt` controller accessing `.length` threw a TypeError the first time it tried to fire.

This just guards that access so bodies without a guns array are skipped instead of erroring out. I tested it locally against the loaded controller (no guns array, with/without alt-fire guns, and the `onlyIfHasAltFireGun` flag) and it works as expected.