### PR TITLE
fix: re-sync game_speed/run_speed after gamemode configs apply

### DIFF
--- a/server/game.js
+++ b/server/game.js
@@ -298,6 +298,10 @@ class gameServer {
                     }
                 }
             };
+            // Re-sync the cached speed values, since the gamemode config may have overridden them (issue #54)
+            this.roomSpeed = Config.game_speed;
+            this.runSpeed = Config.run_speed;
+
             // Update the server gamemode name
             this.name = this.gamemode.map(x => getName(x, Config) || (x[0].toUpperCase() + x.slice(1))).join(' ');
 


### PR DESCRIPTION
Closes #54 

The `gameServer` constructor caches `Config.game_speed` and `run_speed` onto `roomSpeed` / `runSpeed` before gamemode configs are ever applied, so a gamemode overriding those values never actually reaches anything. As a result, everything reads those frozen cached values instead. Manual server properties work only because they're applied _before_ that caching happens.

The fix re-syncs those two cached values from `Config` right after the gamemode configs are applied in `start()`, so the gamemode's values flow through to `cycleSpeed`, gun speeds, movement multiplier, etc. I verified it with `fast.js` (which sets `game_speed: 1.5`.)

Before the fix, `roomSpeed` stays 1 while `Config.game_speed` is `1.5`; after, it picks up as `1.5` as expected. Fixes tested and verified locally.