### PR TITLE
fix `+C +  even more accurate alas

### DIFF
--- a/server/game/addons/keyCommands.js
+++ b/server/game/addons/keyCommands.js
@@ -257,13 +257,26 @@ function init() {
             level: 1,
             operatorAccess: true,
             run: ({ player }) => {
+                const colors = [
+                    "teal", "shiny", "triangle",
+                    "yellow", "lavender", "aqua",
+                    "crasher", "egg", "wall", 
+                    "pureWhite", "black", "blue",
+                    "green", "red", "square",
+                    "pentagon", "magenta", "grey",
+                    "rogue", "white", "pureBlack",
+                    "animatedBlueRed", "animatedBlueGrey", "animatedGreyBlue",
+                    "animatedRedGrey", "animatedGreyRed", "mustard",
+                    "tangerine", "brown", "cyan", 
+                    "lesbian", "rainbow", "trans",
+                    "trueTrans", "bi", "animatedMagenta",
+                ]
                 let target = targetEntities(player);
                 if (target.length) {
                     let o = target[0];
-                    if (o.color.base > 42) {
-                        o.color.base = 1;
-                    }
-                    o.color.base += 1;
+                    const color = typeof o.color.base === "number" ? colors[o.color.base + 1] : colors[colors.indexOf(o.color.base) + 1];
+                    if (!color) return o.color.base = colors[0];
+                    o.color.base = color;
                 }
             }
         },

--- a/server/lib/definitions/groups/tanks.js
+++ b/server/lib/definitions/groups/tanks.js
@@ -10095,7 +10095,7 @@ Class.alas = {
     LABEL: "Alas",
     DANGER: 9,
     STAT_NAMES: statnames.drone,
-    BODY: Class.director.BODY,
+    BODY: Class.manager.BODY,
     INVISIBLE: [0.08, 0.03],
     GUNS: [
         {

--- a/server/lib/definitions/groups/tanks.js
+++ b/server/lib/definitions/groups/tanks.js
@@ -10100,13 +10100,13 @@ Class.alas = {
     GUNS: [
         {
             POSITION: {
-                LENGTH: 5,
-                WIDTH: 11,
-                ASPECT: 1.3,
+                LENGTH: 6,
+                WIDTH: 12,
+                ASPECT: 1.2,
                 X: 8
             },
             PROPERTIES: {
-                SHOOT_SETTINGS: combineStats([g.drone, {speed: 5}]),
+                SHOOT_SETTINGS: combineStats([g.drone, g.overseer, { reload: 0.5, speed: 5}]),
                 TYPE: 'drone',
                 AUTOFIRE: true,
                 SYNCS_SKILLS: true,
@@ -10117,7 +10117,7 @@ Class.alas = {
         },
         {
             POSITION: {
-                LENGTH: 5,
+                LENGTH: 5.5,
                 WIDTH: 6,
                 ASPECT: -1.5,
                 X: 8

--- a/server/lib/definitions/groups/tanks.js
+++ b/server/lib/definitions/groups/tanks.js
@@ -10125,7 +10125,7 @@ Class.alas = {
         },
         {
             POSITION: {
-                LENGTH: 7.5,
+                LENGTH: 8,
                 WIDTH: 1.5,
                 ASPECT: -4,
                 X: 8
@@ -10194,7 +10194,7 @@ Class.quadCyclone = {
     PARENT: "genericTank",
     LABEL: "Quad Cyclone",
     TURRETS: weaponArray({
-        POSITION: {SIZE: 20, LAYER: 1, X: 25},
+        POSITION: {SIZE: 20, LAYER: 1, X: 25, ARC: 0},
         TYPE: 'cycloneTurret'
     }, 4),
     GUNS: weaponArray({

--- a/server/lib/definitions/groups/tanks.js
+++ b/server/lib/definitions/groups/tanks.js
@@ -10111,7 +10111,7 @@ Class.alas = {
                 AUTOFIRE: true,
                 SYNCS_SKILLS: true,
                 STAT_CALCULATOR: 'drone',
-                MAX_CHILDREN: 6,
+                MAX_CHILDREN: 8,
                 WAIT_TO_CYCLE: true
             }
         },


### PR DESCRIPTION
`+C works now, and changed alas a bit because it's a stronger version of manager not director from what I know, also added arc: 0 on quad cyclone from dev branch